### PR TITLE
商品一覧表示実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!,except:[:index]
+  before_action :authenticate_user!, except: [:index]
   def index
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,12 +22,12 @@ class Item < ApplicationRecord
   end
 
   with_options numericality: { other_than: 1 } do
-  validates :category_id
-  validates :sales_status_id
-  validates :shipping_fee_status_id
-  validates :prefecture_id
-  validates :scheduled_delivery_id
+    validates :category_id
+    validates :sales_status_id
+    validates :shipping_fee_status_id
+    validates :prefecture_id
+    validates :scheduled_delivery_id
   end
-  
+
   validates :item_price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,26 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <%# 商品購入機能実装後、実装予定 %>
+          <%# <div class='sold-out'> %>
+          <%# <span>Sold Out!!</span> %>
+          <%# </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.item_price %>円<br><%= item.shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +154,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless Item.exists? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,7 +175,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
+      <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -157,7 +157,7 @@
       <% end %>
 
       <%# 商品がない場合のダミー %>
-      <% unless @item.blank? %>
+      <% if @items.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -157,7 +157,7 @@
       <% end %>
 
       <%# 商品がない場合のダミー %>
-      <% unless Item.exists? %>
+      <% unless @item.blank? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :user do  
+  factory :user do
     nickname { 'suzutaro' }
     email { Faker::Internet.free_email }
     password { Faker::Internet.password(min_length: 6) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Item, type: :model do
     end
 
     it 'item_priceは10_000_000以下では保存できない' do
-      @item.item_price = 100000000
+      @item.item_price = 100_000_000
       @item.valid?
       expect(@item.errors.full_messages).to include('Item price is out of setting range')
     end


### PR DESCRIPTION
本件、実装しましたのでご確認お願いします。

# What
①出品した商品をトップページに表示する
②出品した商品をログイン関係なく閲覧できる
③一番新しく出品した商品が一番左に表示される
# Why
①現状の出品している商品について、表示させる必要があるため
②ログイン関係なく商品を閲覧できることで、未会員者の購買意欲が膨らみユーザ会員数が増えるため
③出品者が問題なく出品できたことを確認するため

■実装動画
1.未ログインでも商品閲覧ができる
https://gyazo.com/912fb29accd09cccddf4d356ad4086f2
2.ログイン時に商品閲覧ができる
https://gyazo.com/99aeba724d872db778a406f136d7b4d9
3・4.商品登録時に一番左側(最新)に商品が表示される
https://gyazo.com/963d40430d9140fc8db91ab84253a34c
https://gyazo.com/19a4675b43df2504129bb0bf79728732